### PR TITLE
Change 'random' function description

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -347,7 +347,7 @@ Get random element from list
 
 ```javascript
 const numbers = l(3, 4, 5, 8);
-random(); // one random item from 3, 4, 5, 8
+random(numbers); // one random item from 3, 4, 5, 8
 ```
 
 ## toString

--- a/src/index.js
+++ b/src/index.js
@@ -269,7 +269,7 @@ export const get = (index, list) => {
  * Get random element from list
  * @example
  * const numbers = l(3, 4, 5, 8);
- * random(); // one random item from 3, 4, 5, 8
+ * random(numbers); // one random item from 3, 4, 5, 8
  */
 export const random = (list) => {
   checkList(list);


### PR DESCRIPTION
There is an error in the description of how the function 'random' can be called, i.e. there is no parameter.